### PR TITLE
Update readme AMD import syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ Ember-add-on to keep track of your Rails CSRF-token.
 
 ```js
 app.import('vendor/rails-csrf/dist/named-amd/main.js', {
-  'rails-csrf': [
-    'setCsrfUrl'
-  ]
+  exports: {
+    'rails-csrf': [
+      'setCsrfUrl'
+    ]
+  }
 });
 ```
 * In `app.js` add load initializers


### PR DESCRIPTION
Hey Adolfo!

I needed to put this setup in an `exports` object to make this work. See [this ember-cli documentation](http://www.ember-cli.com/#standard-amd-asset) for more info.

Thanks for the useful add-on.
