### PR TITLE
fix default api url to work on IE8

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ export default Ember.Route.extend({
 ```
 
 ## Config
-By default `rails-csrf` does a get request to `api/csrf`, if you
+By default `rails-csrf` does a get request to `/api/csrf`, if you
 want to customize the end-point use `setCsrfUrl` on app.js
 
 ```js
 import { setCsrfUrl } from 'rails-csrf/config';
 
-setCsrfUrl('api/your/own/endpoint');
+setCsrfUrl('/api/your/own/endpoint');
 ...
 loadInitializers(App, 'rails-csrf');
 ```

--- a/addon/config.js
+++ b/addon/config.js
@@ -1,5 +1,5 @@
 var __config__ = {
-  url: 'api/csrf'
+  url: '/api/csrf'
 };
 
 export function set(key, value) {


### PR DESCRIPTION
@abuiles first of all thanks, for this :)

I started using it into an app that has to support IE8 and found a bunch of small issues, I'll open a few PR, feel free to accept them or not depending on what you think is the best plan of action.

from the looks of it when location is not history the api requests will got to
`currenturl/api/csrf' instead of`yourdomain/api/csrf`

given that that's the endpoint that the documentation suggests to create I think it will be good to add the starting `/` and prevent this from happening

If this doesn't sound good and there's another reason that I'm missing for not having the initial '/' that's fine, I can use the provided api to customize the url the way I need it
