### PR TITLE
use Ember.keys instead of Object.keys for older browsers support

### DIFF
--- a/addon/service.js
+++ b/addon/service.js
@@ -22,7 +22,7 @@ export default Ember.Object.extend({
     $.ajaxPrefilter(preFilter);
   },
   setData: function(data) {
-    var param = Object.keys(data)[0];
+    var param = Ember.keys(data)[0];
     this.set('data', { param: param, token: data[param] });
     this.setPrefilter();
 


### PR DESCRIPTION
IE8 breaks (as usual) because of this :/
https://github.com/emberjs/ember.js/blob/v1.8.1/packages/ember-metal/lib/keys.js#L3
