### PR TITLE
Clarify Integration Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,12 @@ end
 
 ## Working With Integration Tests
 Be sure to mock out the call to the csrf server endpoint. Otherwise your tests
-will fail with "error while processing route: [route]" messages in the
-browser console. For example:
+will fail with 
+```
+"error while processing route: [route]"
+```
+messages in the browser console. For example:
+
 ```
 server = new Pretender(function() {
 this.get('/csrf', function(request) {


### PR DESCRIPTION
This addon is great. Unfortunately for me, I didn't think to add the /csrf endpoint to my integration tests. The only error I got was "error while processing route: [my_route]" in the console, which didn't point me to the csrf endpoint until I spent a lot of time trying other things. I hope this PR can help others work this out more quickly.
