### PR TITLE
Replace Ember.keys with Object.keys

### DIFF
--- a/app/services/csrf.js
+++ b/app/services/csrf.js
@@ -24,7 +24,7 @@ export default Ember.Object.extend({
     $.ajaxPrefilter(preFilter);
   },
   setData: function(data) {
-    var param = Ember.keys(data)[0];
+    var param = Object.keys(data)[0];
     this.set('data', { param: param, token: data[param] });
     this.setPrefilter();
 


### PR DESCRIPTION
This removes a deprecation warning in Ember.js 1.13.