### PR TITLE
get rid of Ember 2.0 initializer warnings

### DIFF
--- a/app/initializers/csrf-service.js
+++ b/app/initializers/csrf-service.js
@@ -1,8 +1,8 @@
 export default {
   name: 'rails-csrf',
-  initialize: function() {
-    let app = arguments[1] || arguments[0];
-    app.inject('route',      'csrf', 'service:csrf');
-    app.inject('controller', 'csrf', 'service:csrf');
+  initialize: function(app) {
+    let App = arguments[1] || app;
+    App.inject('route',      'csrf', 'service:csrf');
+    App.inject('controller', 'csrf', 'service:csrf');
   }
 };


### PR DESCRIPTION
This gets rid of some deprecation warnings about the number of args the initialize function should take, while still maintaining backwards compat, though I dunno which old  version of Ember actually depended on this.
